### PR TITLE
refactor: Reorganize action interfaces and implementations

### DIFF
--- a/core/impl/action.py
+++ b/core/impl/action.py
@@ -1,0 +1,43 @@
+from enum import Enum
+from typing import Any, Dict
+
+from core.interfaces.base_action import IMTAction, MTDevice
+
+
+class MTMouseAction(Enum, IMTAction):
+    """마우스 액션 유형"""
+    CLICK = "click"
+    DOUBLE_CLICK = "doubleclick"
+    RIGHT_CLICK = "rightclick"
+    DRAG = "drag"
+    MOVE = "move"
+    
+    def get_action_id(self) -> str:
+        """액션 ID(값)을 반환합니다."""
+        return self.value
+    
+    def get_action_params(self) -> Dict[str, Any]:
+        """액션 매개변수를 반환합니다."""
+        return {}
+    
+    def get_device_type(self) -> MTDevice:
+        """액션의 장치 유형을 반환합니다."""
+        return MTDevice.MOUSE
+
+
+class MTKeyboardAction(Enum, IMTAction):
+    """키보드 액션 유형"""
+    TYPE = "type"
+    SHORTCUT = "shortcut"
+    
+    def get_action_id(self) -> str:
+        """액션 ID(값)을 반환합니다."""
+        return self.value
+    
+    def get_action_params(self) -> Dict[str, Any]:
+        """액션 매개변수를 반환합니다."""
+        return {}
+    
+    def get_device_type(self) -> MTDevice:
+        """액션의 장치 유형을 반환합니다."""
+        return MTDevice.KEYBOARD 

--- a/core/impl/tree_item.py
+++ b/core/impl/tree_item.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, TypeVar
+from typing import Any, Dict, TypeVar
 
 from core.interfaces.base_item import IMTTreeItem
 from core.types.item_types import TreeItemData
@@ -8,7 +8,7 @@ T = TypeVar('T')  # 제네릭 타입 변수 정의
 class MTTreeItem(IMTTreeItem):
     """매크로 트리 아이템 구현 클래스"""
     
-    def __init__(self, item_id: str, initial_data: Optional[Dict[str, Any]] = None):
+    def __init__(self, item_id: str, initial_data: Dict[str, Any] | None = None):
         """아이템 초기화
         
         Args:
@@ -28,11 +28,7 @@ class MTTreeItem(IMTTreeItem):
         """아이템 데이터를 반환합니다."""
         return self._data.copy()
     
-    def get_id(self) -> str:
-        """아이템 ID를 반환합니다."""
-        return self._id
-    
-    def get_property(self, key: str, default: Optional[T] = None) -> Optional[T]:
+    def get_property(self, key: str, default: T | None = None) -> T | None:
         """아이템 속성을 가져옵니다."""
         return self._data.get(key, default)
     

--- a/core/interfaces/base_action.py
+++ b/core/interfaces/base_action.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from typing import Any, Dict, List, Protocol, Tuple, TypeVar
+
+class MTNode(Enum):
+    """매크로 트리의 노드 유형"""
+    GROUP = "group"
+    INSTRUCTION = "instruction"
+
+
+class MTDevice(Enum):
+    """매크로 트리에서 사용하는 입력 장치 유형"""
+    MOUSE = "mouse"
+    KEYBOARD = "keyboard"
+    JOYSTICK = "joystick"
+
+
+class MTKeyState(Enum):
+    """키 상태"""
+    PRESSED = "pressed"
+    RELEASED = "released"
+
+
+class IMTAction(Protocol):
+    """액션 인터페이스"""
+    def get_action_id(self) -> str: ...
+    
+    def get_action_params(self) -> Dict[str, Any]: ...
+    
+    def get_device_type(self) -> MTDevice: ...
+
+
+# 좌표 인터페이스
+class IMTPoint(Protocol):
+    """2D 좌표 인터페이스"""
+    @property
+    def x(self) -> int: ...
+    
+    @property
+    def y(self) -> int: ...
+    
+    def clone(self) -> 'IMTPoint': ...
+
+
+# 액션 데이터 인터페이스
+class IMTActionData(Protocol):
+    """액션 데이터 기본 인터페이스"""
+    def get_device_type(self) -> MTDevice: ...
+    
+    def clone(self) -> 'IMTActionData': ...
+
+
+# 마우스 액션 데이터 인터페이스
+class IMTMouseActionData(IMTActionData, Protocol):
+    """마우스 액션 데이터 인터페이스"""
+    @property
+    def position(self) -> IMTPoint: ...
+    
+    @property
+    def end_position(self) -> IMTPoint | None: ...
+    
+    @property
+    def button(self) -> str: ...
+
+
+# 키보드 액션 데이터 인터페이스
+class IMTKeyboardActionData(IMTActionData, Protocol):
+    """키보드 액션 데이터 인터페이스"""
+    @property
+    def action_type(self) -> 'MTKeyboardAction': ...
+    
+    def get_key_sequence(self) -> List[Tuple[str, MTKeyState]]: ...
+    
+    def add_key(self, key: str, state: MTKeyState) -> None: ...
+    
+    def clear(self) -> None: ... 

--- a/core/interfaces/base_item.py
+++ b/core/interfaces/base_item.py
@@ -1,5 +1,6 @@
-from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, Protocol, Tuple, TypeVar, runtime_checkable
+from typing import Any, Dict, Protocol, TypeVar, runtime_checkable
+
+from core.interfaces.base_action import IMTActionData, MTDevice, MTKeyState
 
 # 타입 변수 정의
 T = TypeVar('T')  # 제네릭 타입 변수 정의
@@ -13,14 +14,27 @@ class IMTBaseItem(Protocol):
     @property
     def data(self) -> Dict[str, Any]: ...
 
-# MTAction 관련 인터페이스
-class IMTAction(Protocol):
-    """액션 인터페이스"""
-    def get_action_id(self) -> str: ...
+# 트리 아이템 인터페이스
+@runtime_checkable
+class IMTTreeItem(IMTBaseItem, Protocol):
+    """매크로 트리 아이템 인터페이스
     
-    def get_action_params(self) -> Dict[str, Any]: ...
+    트리에서 사용되는 개별 아이템의 인터페이스입니다.
+    id만 직접 접근 속성으로 제공하고, 나머지는 data 딕셔너리를 통해 액세스합니다.
+    """
+    # id와 data 프로퍼티는 IMTBaseItem에서 이미 정의됨
     
-    def get_device_type(self) -> 'MTDevice': ...
+    def get_property(self, key: str, default: T | None = None) -> T | None:
+        """아이템 속성을 가져옵니다."""
+        ...
+    
+    def set_property(self, key: str, value: T) -> None:
+        """아이템 속성을 설정합니다."""
+        ...
+    
+    def clone(self) -> 'IMTTreeItem':
+        """아이템의 복제본을 생성합니다."""
+        ...
 
 # 좌표 인터페이스
 class IMTPoint(Protocol):
@@ -36,7 +50,7 @@ class IMTPoint(Protocol):
 # 액션 데이터 인터페이스
 class IMTActionData(Protocol):
     """액션 데이터 기본 인터페이스"""
-    def get_device_type(self) -> 'MTDevice': ...
+    def get_device_type(self) -> MTDevice: ...
     
     def clone(self) -> 'IMTActionData': ...
 
@@ -47,7 +61,7 @@ class IMTMouseActionData(IMTActionData, Protocol):
     def position(self) -> IMTPoint: ...
     
     @property
-    def end_position(self) -> Optional[IMTPoint]: ...
+    def end_position(self) -> IMTPoint | None: ...
     
     @property
     def button(self) -> str: ...
@@ -58,34 +72,9 @@ class IMTKeyboardActionData(IMTActionData, Protocol):
     @property
     def action_type(self) -> 'MTKeyboardAction': ...
     
-    def get_key_sequence(self) -> List[Tuple[str, 'MTKeyState']]: ...
+    def get_key_sequence(self) -> List[Tuple[str, MTKeyState]]: ...
     
-    def add_key(self, key: str, state: 'MTKeyState') -> None: ...
+    def add_key(self, key: str, state: MTKeyState) -> None: ...
     
     def clear(self) -> None: ...
 
-# 트리 아이템 인터페이스
-@runtime_checkable
-class IMTTreeItem(IMTBaseItem, Protocol):
-    """매크로 트리 아이템 인터페이스
-    
-    트리에서 사용되는 개별 아이템의 인터페이스입니다.
-    id만 직접 접근 속성으로 제공하고, 나머지는 data 딕셔너리를 통해 액세스합니다.
-    """
-    # id와 data 프로퍼티는 IMTBaseItem에서 이미 정의됨
-    
-    def get_id(self) -> str:
-        """아이템 ID 반환"""
-        ...
-    
-    def get_property(self, key: str, default: Optional[T] = None) -> Optional[T]:
-        """아이템 속성을 가져옵니다."""
-        ...
-    
-    def set_property(self, key: str, value: T) -> None:
-        """아이템 속성을 설정합니다."""
-        ...
-    
-    def clone(self) -> 'IMTTreeItem':
-        """아이템의 복제본을 생성합니다."""
-        ... 

--- a/core/interfaces/base_tree.py
+++ b/core/interfaces/base_tree.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Dict, Generic, Iterator, List, Optional, Protocol, TypeVar
+from typing import Any, Callable, Dict, Generic, Iterator, List, Protocol, TypeVar
 
 from core.interfaces.base_item import IMTTreeItem
 
@@ -29,19 +29,19 @@ class IMTTreeData(Protocol[T]):
     def name(self) -> str: ...
     
     @property
-    def root_id(self) -> Optional[str]: ...
+    def root_id(self) -> str | None: ...
     
     def get_all_items(self) -> Dict[str, T]: ...
     
-    def get_item(self, item_id: str) -> Optional[T]: ...
+    def get_item(self, item_id: str) -> T | None: ...
     
-    def get_children(self, parent_id: Optional[str]) -> List[T]: ...
+    def get_children(self, parent_id: str | None) -> List[T]: ...
 
 # 트리 수정 작업 인터페이스
 class IMTTreeModifiable(Protocol):
     """트리 수정 작업 인터페이스"""
     
-    def add_item(self, item: IMTTreeItem, parent_id: Optional[str] = None) -> bool:
+    def add_item(self, item: IMTTreeItem, parent_id: str | None = None) -> bool:
         """아이템을 트리에 추가합니다. Raises: ValueError-아이템 ID 중복 시"""
         ...
     
@@ -49,7 +49,7 @@ class IMTTreeModifiable(Protocol):
         """아이템을 트리에서 제거합니다. Raises: ValueError-존재하지 않는 아이템 ID"""
         ...
     
-    def move_item(self, item_id: str, new_parent_id: Optional[str]) -> bool:
+    def move_item(self, item_id: str, new_parent_id: str | None) -> bool:
         """아이템을 새 부모로 이동합니다. Raises: ValueError-유효하지 않은 아이템/부모 ID"""
         ...
     
@@ -66,7 +66,7 @@ class IMTTreeTraversable(Protocol):
     """트리 순회 인터페이스"""
     
     def traverse(self, visitor: Callable[[IMTTreeItem], None], 
-                node_id: Optional[str] = None) -> None:
+                node_id: str | None = None) -> None:
         """트리를 BFS로 순회하면서 각 아이템에 방문자 함수를 적용합니다."""
         ...
 

--- a/core/types/item_types.py
+++ b/core/types/item_types.py
@@ -1,91 +1,36 @@
-from enum import Enum
-from typing import Any, Dict, List, Optional, TypedDict, TypeVar
+from typing import Any, Dict, List, TypedDict, TypeVar
 
-from core.interfaces.base_item import IMTAction, IMTActionData
-
-class MTNode(Enum):
-    """매크로 트리의 노드 유형"""
-    GROUP = "group"
-    INSTRUCTION = "instruction"
-
-
-class MTDevice(Enum):
-    """매크로 트리에서 사용하는 입력 장치 유형"""
-    MOUSE = "mouse"
-    KEYBOARD = "keyboard"
-    JOYSTICK = "joystick"
-
-
-class MTAction:
-    """기본 액션 클래스"""
-    def get_action_id(self) -> str:
-        raise NotImplementedError
-    
-    def get_action_params(self) -> Dict[str, Any]:
-        return {}
-    
-    def get_device_type(self) -> MTDevice:
-        raise NotImplementedError
-
-
-class MTMouseAction(Enum, MTAction):
-    CLICK = "click"
-    DOUBLE_CLICK = "doubleclick"
-    RIGHT_CLICK = "rightclick"
-    DRAG = "drag"
-    MOVE = "move"
-    
-    def get_action_id(self) -> str:
-        return self.value
-    
-    def get_action_params(self) -> Dict[str, Any]:
-        return {}
-    
-    def get_device_type(self) -> MTDevice:
-        return MTDevice.MOUSE
-
-
-class MTKeyboardAction(Enum, MTAction):
-    TYPE = "type"
-    SHORTCUT = "shortcut"
-    
-    def get_action_id(self) -> str:
-        return self.value
-    
-    def get_action_params(self) -> Dict[str, Any]:
-        return {}
-    
-    def get_device_type(self) -> MTDevice:
-        return MTDevice.KEYBOARD
-
-
-class MTKeyState(Enum):
-    """키 상태"""
-    PRESSED = "pressed"
-    RELEASED = "released"
-
+from core.interfaces.base_action import IMTAction, IMTActionData, MTNode
 
 class TreeItemData(TypedDict, total=False): # dict 의 value 값 검증을 위해 타입을 규정함
     """트리 아이템 데이터 구조 (total=False: 모든 필드 선택적)"""
     node_type: MTNode  # 노드 유형 (그룹/지시 등)
     name: str  # 아이템 이름
-    parent_id: Optional[str]  # 부모 아이템 ID
+    parent_id: str | None  # 부모 아이템 ID
     children_ids: List[str]  # 자식 아이템 ID 목록
-    action_type: Optional[IMTAction]  # 액션 타입
-    action_data: Optional[IMTActionData]  # 액션 데이터
+    action_type: IMTAction | None  # 액션 타입
+    action_data: IMTActionData | None  # 액션 데이터
 
 T = TypeVar('T')  # 제네릭 타입 변수 정의
 
 class TreeItemKeys:
-    """트리 아이템 속성 키 상수 정의"""
+    """트리 아이템 속성 키 상수 정의
+    
+    이 클래스는 두 그룹으로 나뉩니다:
+    1. TreeItemData 필드에 직접 매핑되는 키
+    2. 추가적인 UI 및 기능 관련 키
+    """
+    # TreeItemData에 매핑되는 키
+    NAME = "name"                # TreeItemData.name
+    PARENT_ID = "parent_id"      # TreeItemData.parent_id
+    CHILDREN = "children"        # TreeItemData.children_ids
+    TYPE = "type"                # TreeItemData.node_type
+    ACTION = "action"            # TreeItemData.action_type
+    ACTION_DATA = "action_data"  # TreeItemData.action_data
+    
+    # 추가 기능 키 (TreeItemData에 직접 매핑되지 않음)
     ID = "id"
-    NAME = "name"
-    PARENT_ID = "parent_id"
-    CHILDREN = "children"
     DATA = "data"
-    TYPE = "type"
-    ACTION = "action"
-    ACTION_DATA = "action_data"
     EXPANDED = "expanded"
     SELECTED = "selected"
     VISIBLE = "visible"

--- a/docs/model/tree_item.html
+++ b/docs/model/tree_item.html
@@ -56,7 +56,7 @@ el.replaceWith(d);
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class IMTActionType(Protocol):
-    def get_action_id(self) -&gt; str:
+    def get_action_name(self) -&gt; str:
         ...
     
     def get_action_params(self) -&gt; Dict[str, Any]:
@@ -98,15 +98,15 @@ Protocol classes can be generic, they are defined as::</p>
 </ul>
 <h3>Methods</h3>
 <dl>
-<dt id="model.tree_item.IMTActionType.get_action_id"><code class="name flex">
-<span>def <span class="ident">get_action_id</span></span>(<span>self) ‑> str</span>
+<dt id="model.tree_item.IMTActionType.get_action_name"><code class="name flex">
+<span>def <span class="ident">get_action_name</span></span>(<span>self) ‑> str</span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_action_id(self) -&gt; str:
+<pre><code class="python">def get_action_name(self) -&gt; str:
     ...</code></pre>
 </details>
 <div class="desc"></div>
@@ -612,7 +612,7 @@ item.set_property(TreeItemKeys.PARENT_ID, parent_id)</p></div>
     TYPE = &#34;type&#34;
     SHORTCUT = &#34;shortcut&#34;
     
-    def get_action_id(self) -&gt; str:
+    def get_action_name(self) -&gt; str:
         return self.value
     
     def get_action_params(self) -&gt; Dict[str, Any]:
@@ -688,15 +688,15 @@ attributes &ndash; see the documentation for details.</p></div>
 </dl>
 <h3>Methods</h3>
 <dl>
-<dt id="model.tree_item.MTKeyboardAction.get_action_id"><code class="name flex">
-<span>def <span class="ident">get_action_id</span></span>(<span>self) ‑> str</span>
+<dt id="model.tree_item.MTKeyboardAction.get_action_name"><code class="name flex">
+<span>def <span class="ident">get_action_name</span></span>(<span>self) ‑> str</span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_action_id(self) -&gt; str:
+<pre><code class="python">def get_action_name(self) -&gt; str:
     return self.value</code></pre>
 </details>
 <div class="desc"></div>
@@ -745,7 +745,7 @@ attributes &ndash; see the documentation for details.</p></div>
     DRAG = &#34;drag&#34;
     MOVE = &#34;move&#34;
     
-    def get_action_id(self) -&gt; str:
+    def get_action_name(self) -&gt; str:
         return self.value
     
     def get_action_params(self) -&gt; Dict[str, Any]:
@@ -833,15 +833,15 @@ attributes &ndash; see the documentation for details.</p></div>
 </dl>
 <h3>Methods</h3>
 <dl>
-<dt id="model.tree_item.MTMouseAction.get_action_id"><code class="name flex">
-<span>def <span class="ident">get_action_id</span></span>(<span>self) ‑> str</span>
+<dt id="model.tree_item.MTMouseAction.get_action_name"><code class="name flex">
+<span>def <span class="ident">get_action_name</span></span>(<span>self) ‑> str</span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_action_id(self) -&gt; str:
+<pre><code class="python">def get_action_name(self) -&gt; str:
     return self.value</code></pre>
 </details>
 <div class="desc"></div>
@@ -1050,7 +1050,7 @@ attributes &ndash; see the documentation for details.</p></div>
 <li>
 <h4><code><a title="model.tree_item.IMTActionType" href="#model.tree_item.IMTActionType">IMTActionType</a></code></h4>
 <ul class="">
-<li><code><a title="model.tree_item.IMTActionType.get_action_id" href="#model.tree_item.IMTActionType.get_action_id">get_action_id</a></code></li>
+<li><code><a title="model.tree_item.IMTActionType.get_action_name" href="#model.tree_item.IMTActionType.get_action_name">get_action_name</a></code></li>
 <li><code><a title="model.tree_item.IMTActionType.get_action_params" href="#model.tree_item.IMTActionType.get_action_params">get_action_params</a></code></li>
 <li><code><a title="model.tree_item.IMTActionType.get_device_type" href="#model.tree_item.IMTActionType.get_device_type">get_device_type</a></code></li>
 </ul>
@@ -1116,7 +1116,7 @@ attributes &ndash; see the documentation for details.</p></div>
 <ul class="">
 <li><code><a title="model.tree_item.MTKeyboardAction.SHORTCUT" href="#model.tree_item.MTKeyboardAction.SHORTCUT">SHORTCUT</a></code></li>
 <li><code><a title="model.tree_item.MTKeyboardAction.TYPE" href="#model.tree_item.MTKeyboardAction.TYPE">TYPE</a></code></li>
-<li><code><a title="model.tree_item.MTKeyboardAction.get_action_id" href="#model.tree_item.MTKeyboardAction.get_action_id">get_action_id</a></code></li>
+<li><code><a title="model.tree_item.MTKeyboardAction.get_action_name" href="#model.tree_item.MTKeyboardAction.get_action_name">get_action_name</a></code></li>
 <li><code><a title="model.tree_item.MTKeyboardAction.get_action_params" href="#model.tree_item.MTKeyboardAction.get_action_params">get_action_params</a></code></li>
 <li><code><a title="model.tree_item.MTKeyboardAction.get_device_type" href="#model.tree_item.MTKeyboardAction.get_device_type">get_device_type</a></code></li>
 </ul>
@@ -1129,7 +1129,7 @@ attributes &ndash; see the documentation for details.</p></div>
 <li><code><a title="model.tree_item.MTMouseAction.DRAG" href="#model.tree_item.MTMouseAction.DRAG">DRAG</a></code></li>
 <li><code><a title="model.tree_item.MTMouseAction.MOVE" href="#model.tree_item.MTMouseAction.MOVE">MOVE</a></code></li>
 <li><code><a title="model.tree_item.MTMouseAction.RIGHT_CLICK" href="#model.tree_item.MTMouseAction.RIGHT_CLICK">RIGHT_CLICK</a></code></li>
-<li><code><a title="model.tree_item.MTMouseAction.get_action_id" href="#model.tree_item.MTMouseAction.get_action_id">get_action_id</a></code></li>
+<li><code><a title="model.tree_item.MTMouseAction.get_action_name" href="#model.tree_item.MTMouseAction.get_action_name">get_action_name</a></code></li>
 <li><code><a title="model.tree_item.MTMouseAction.get_action_params" href="#model.tree_item.MTMouseAction.get_action_params">get_action_params</a></code></li>
 <li><code><a title="model.tree_item.MTMouseAction.get_device_type" href="#model.tree_item.MTMouseAction.get_device_type">get_device_type</a></code></li>
 </ul>

--- a/model/implementations/simple_tree_state_mgr.py
+++ b/model/implementations/simple_tree_state_mgr.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, List, Optional, Set
 from copy import deepcopy
 
-from core.tree import IMTTree
+from core.interfaces.base_tree import IMTTree
 from model.tree_state_mgr import IMTTreeStateManager
 
 class SimpleTreeStateManager(IMTTreeStateManager):

--- a/model/item_types.py
+++ b/model/item_types.py
@@ -1,0 +1,93 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar
+
+from core.base_item import IMTBaseItem, IMTAction, IMTActionData
+
+
+class MTNode(Enum):
+    """매크로 트리의 노드 유형"""
+    GROUP = "group"
+    INSTRUCTION = "instruction"
+
+
+class MTDevice(Enum):
+    """매크로 트리에서 사용하는 입력 장치 유형"""
+    MOUSE = "mouse"
+    KEYBOARD = "keyboard"
+    JOYSTICK = "joystick"
+
+
+class MTAction:
+    """기본 액션 클래스"""
+    def get_action_name(self) -> str:
+        raise NotImplementedError
+    
+    def get_action_params(self) -> Dict[str, Any]:
+        return {}
+    
+    def get_device_type(self) -> MTDevice:
+        raise NotImplementedError
+
+
+class MTMouseAction(Enum, MTAction):
+    CLICK = "click"
+    DOUBLE_CLICK = "doubleclick"
+    RIGHT_CLICK = "rightclick"
+    DRAG = "drag"
+    MOVE = "move"
+    
+    def get_action_name(self) -> str:
+        return self.value
+    
+    def get_action_params(self) -> Dict[str, Any]:
+        return {}
+    
+    def get_device_type(self) -> MTDevice:
+        return MTDevice.MOUSE
+
+
+class MTKeyboardAction(Enum, MTAction):
+    TYPE = "type"
+    SHORTCUT = "shortcut"
+    
+    def get_action_name(self) -> str:
+        return self.value
+    
+    def get_action_params(self) -> Dict[str, Any]:
+        return {}
+    
+    def get_device_type(self) -> MTDevice:
+        return MTDevice.KEYBOARD
+
+
+class MTKeyState(Enum):
+    """키 상태"""
+    PRESSED = "pressed"
+    RELEASED = "released"
+
+
+class TreeItemData(TypedDict, total=False): # dict 의 value 값 검증을 위해 타입을 규정함
+    """트리 아이템 데이터 구조 (total=False: 모든 필드 선택적)"""
+    node_type: MTNode  # 노드 유형 (그룹/지시 등)
+    name: str  # 아이템 이름
+    parent_id: Optional[str]  # 부모 아이템 ID
+    children_ids: List[str]  # 자식 아이템 ID 목록
+    action_type: Optional[IMTAction]  # 액션 타입
+    action_data: Optional[IMTActionData]  # 액션 데이터
+
+T = TypeVar('T')  # 제네릭 타입 변수 정의
+
+class TreeItemKeys:
+    """트리 아이템 속성 키 상수 정의"""
+    ID = "id"
+    NAME = "name"
+    PARENT_ID = "parent_id"
+    CHILDREN = "children"
+    DATA = "data"
+    TYPE = "type"
+    ACTION = "action"
+    ACTION_DATA = "action_data"
+    EXPANDED = "expanded"
+    SELECTED = "selected"
+    VISIBLE = "visible"
+    ICON = "icon" 

--- a/model/repository/simple_tree_repository.py
+++ b/model/repository/simple_tree_repository.py
@@ -1,70 +1,90 @@
 import json
 import os
-import uuid
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict
+from uuid import uuid4
 
 from core.interfaces.base_tree import IMTTree
-from core.impl.tree import MTTree
 from model.tree_repo import IMTTreeRepository
 
+
 class SimpleTreeRepository(IMTTreeRepository):
-    """파일 기반 매크로 트리 저장소 구현"""
+    """파일 기반 트리 저장소"""
     
-    def __init__(self, base_path: str = "./data"):
-        self.base_path = base_path
-        os.makedirs(base_path, exist_ok=True)
+    def __init__(self, directory_path: str = "./data"):
+        """저장소 초기화"""
+        self.directory = directory_path
+        os.makedirs(directory_path, exist_ok=True)
     
-    def save(self, tree: IMTTree, name: Optional[str] = None) -> str:
+    def save(self, tree: IMTTree, name: str | None = None) -> str:
         """트리를 저장합니다."""
-        tree_id = str(tree.id) if name is None else name
-        tree_data = self.to_json(tree)
-        file_path = os.path.join(self.base_path, f"{tree_id}.json")
+        tree_data = tree.to_dict()
         
+        # 이름이 제공되지 않으면 트리 이름 사용
+        if name is None:
+            name = tree_data.get("name", "Unnamed Tree")
+        
+        # 저장 파일명 생성
+        tree_id = tree_data.get("id", str(uuid4()))
+        filename = f"{tree_id}.json"
+        file_path = os.path.join(self.directory, filename)
+        
+        # JSON으로 저장
         with open(file_path, 'w', encoding='utf-8') as f:
-            json.dump(tree_data, f, indent=2, ensure_ascii=False)
+            json.dump(tree_data, f, ensure_ascii=False, indent=2)
         
         return tree_id
     
-    def load(self, identifier: Optional[str] = None) -> IMTTree:
+    def load(self, identifier: str | None = None) -> IMTTree:
         """트리를 불러옵니다."""
+        # 식별자가 없으면 가장 최근 파일 사용
         if identifier is None:
-            # 가장 최근 파일 찾기
-            files = self._list_tree_files()
-            if not files:
+            files = os.listdir(self.directory)
+            json_files = [f for f in files if f.endswith('.json')]
+            
+            if not json_files:
                 raise ValueError("저장된 트리가 없습니다.")
-            identifier = sorted(files, key=lambda f: os.path.getmtime(
-                os.path.join(self.base_path, f)))[-1].rsplit('.', 1)[0]
+            
+            # 최신 파일 (수정 시간 기준)
+            json_files.sort(key=lambda x: os.path.getmtime(os.path.join(self.directory, x)), reverse=True)
+            filename = json_files[0]
+        else:
+            filename = f"{identifier}.json"
         
-        file_path = os.path.join(self.base_path, f"{identifier}.json")
+        file_path = os.path.join(self.directory, filename)
+        
+        # 파일 존재 확인
         if not os.path.exists(file_path):
-            raise ValueError(f"트리를 찾을 수 없음: {identifier}")
+            raise ValueError(f"트리 파일을 찾을 수 없습니다: {filename}")
         
+        # JSON 파일 로드
         with open(file_path, 'r', encoding='utf-8') as f:
             tree_data = json.load(f)
         
-        return self.from_json(json.dumps(tree_data))
+        # 트리 객체 생성
+        from core.impl.tree import SimpleTree
+        return SimpleTree.from_dict(tree_data)
     
     def delete(self, identifier: str) -> bool:
         """저장된 트리를 삭제합니다."""
-        file_path = os.path.join(self.base_path, f"{identifier}.json")
+        filename = f"{identifier}.json"
+        file_path = os.path.join(self.directory, filename)
+        
         if os.path.exists(file_path):
             os.remove(file_path)
             return True
+        
         return False
     
-    def to_json(self, tree: IMTTree) -> Dict[str, Any]:
-        """트리를 JSON으로 변환합니다."""
-        return tree.to_dict()
+    def to_json(self, tree: IMTTree) -> str:
+        """트리를 JSON 문자열로 변환합니다."""
+        tree_data = tree.to_dict()
+        return json.dumps(tree_data, ensure_ascii=False, indent=2)
     
     def from_json(self, json_str: str) -> IMTTree:
-        """JSON에서 트리를 생성합니다."""
+        """JSON 문자열에서 트리를 생성합니다."""
         try:
             tree_data = json.loads(json_str)
-            # 구현체에 맞게 수정 필요
-            return MTTree.from_dict(tree_data)
+            from core.impl.tree import SimpleTree
+            return SimpleTree.from_dict(tree_data)
         except json.JSONDecodeError as e:
-            raise ValueError(f"잘못된 JSON 형식: {e}")
-    
-    def _list_tree_files(self) -> List[str]:
-        """저장된 트리 파일 목록을 반환합니다."""
-        return [f for f in os.listdir(self.base_path) if f.endswith('.json')]
+            raise ValueError(f"잘못된 JSON 형식: {str(e)}")

--- a/model/state/simple_tree_state_mgr.py
+++ b/model/state/simple_tree_state_mgr.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Set
 from copy import deepcopy
 
 from core.interfaces.base_tree import IMTTree
@@ -13,6 +13,15 @@ class SimpleTreeStateManager(IMTTreeStateManager):
         self._history: List[IMTTree] = []
         self._current_index: int = -1
         self._subscribers: Set[Callable] = set()
+    
+    def set_initial_state(self, tree: IMTTree) -> None:
+        """초기 상태를 설정합니다."""
+        # 기존 이력 초기화
+        self._history = []
+        self._current_index = -1
+        
+        # 새 상태 저장
+        self.save_state(tree)
     
     def save_state(self, tree: IMTTree) -> None:
         """현재 트리 상태를 이력에 저장"""
@@ -34,7 +43,8 @@ class SimpleTreeStateManager(IMTTreeStateManager):
         # 구독자에게 알림
         self._notify_subscribers()
     
-    def current_state(self) -> Optional[IMTTree]:
+    @property
+    def current_state(self) -> IMTTree | None:
         """현재 트리 상태를 반환"""
         if self._current_index >= 0 and self._current_index < len(self._history):
             return self._history[self._current_index]
@@ -48,23 +58,23 @@ class SimpleTreeStateManager(IMTTreeStateManager):
         """다시 실행 가능 여부 확인"""
         return self._current_index < len(self._history) - 1
     
-    def undo(self) -> Optional[IMTTree]:
+    def undo(self) -> IMTTree | None:
         """이전 상태로 되돌리기"""
         if not self.can_undo():
             return None
         
         self._current_index -= 1
         self._notify_subscribers()
-        return self.current_state()
+        return self.current_state
     
-    def redo(self) -> Optional[IMTTree]:
+    def redo(self) -> IMTTree | None:
         """다음 상태로 복원"""
         if not self.can_redo():
             return None
         
         self._current_index += 1
         self._notify_subscribers()
-        return self.current_state()
+        return self.current_state
     
     def clear(self) -> None:
         """모든 상태 이력 초기화"""
@@ -83,6 +93,6 @@ class SimpleTreeStateManager(IMTTreeStateManager):
     
     def _notify_subscribers(self) -> None:
         """모든 구독자에게 상태 변경을 알립니다."""
-        current = self.current_state()
+        current = self.current_state
         for callback in self._subscribers:
             callback(current)

--- a/model/tree_repo.py
+++ b/model/tree_repo.py
@@ -9,11 +9,11 @@ class IMTTreeRepository(Protocol):
     트리 데이터의 영속성을 관리합니다.
     """
     
-    def save(self, tree: IMTTree, name: Optional[str] = None) -> str:
+    def save(self, tree: IMTTree, name: str | None = None) -> str:
         """트리를 저장합니다. Raises: TreeSaveError-저장 실패 시"""
         ...
     
-    def load(self, identifier: Optional[str] = None) -> IMTTree:
+    def load(self, identifier: str | None = None) -> IMTTree:
         """트리를 불러옵니다. Raises: TreeNotFoundError-트리를 찾을 수 없을 때"""
         ...
     

--- a/model/tree_state_mgr.py
+++ b/model/tree_state_mgr.py
@@ -5,34 +5,42 @@ from core.interfaces.base_item import IMTTreeItem
 
 
 class IMTTreeStateManager(Protocol):
-    """매크로 트리 상태 관리자 인터페이스"""
+    """매크로 트리 상태 관리자 인터페이스
+    
+    트리의 상태 변경을 추적하고 관리합니다.
+    """
     
     def __init__(self, max_history: int = 50):
         """상태 관리자를 초기화합니다."""
         ...
     
-    def save_state(self, tree: IMTTree) -> None:
-        """현재 트리 상태를 이력에 저장"""
+    def set_initial_state(self, tree: IMTTree) -> None:
+        """초기 상태를 설정합니다."""
         ...
     
-    def current_state(self) -> Optional[IMTTree]:
-        """현재 트리 상태를 반환"""
+    @property
+    def current_state(self) -> IMTTree | None:
+        """현재 상태의 트리를 반환합니다."""
+        ...
+    
+    def save_state(self) -> None:
+        """현재 상태를 저장합니다."""
         ...
     
     def can_undo(self) -> bool:
-        """실행 취소 가능 여부 확인"""
+        """되돌리기 가능 여부를 반환합니다."""
         ...
     
     def can_redo(self) -> bool:
-        """다시 실행 가능 여부 확인"""
+        """다시 실행 가능 여부를 반환합니다."""
         ...
     
-    def undo(self) -> Optional[IMTTree]:
-        """이전 상태로 되돌리기"""
+    def undo(self) -> IMTTree | None:
+        """이전 상태로 되돌립니다."""
         ...
     
-    def redo(self) -> Optional[IMTTree]:
-        """다음 상태로 복원"""
+    def redo(self) -> IMTTree | None:
+        """다음 상태로 복원합니다."""
         ...
     
     def clear(self) -> None:

--- a/viewmodel/implementations/simple_tree_viewmodel.py
+++ b/viewmodel/implementations/simple_tree_viewmodel.py
@@ -1,226 +1,309 @@
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Callable, Set
 import os
+from uuid import uuid4
 from ...model.implementations.simple_tree import SimpleTree
 from ...model.implementations.simple_tree_item import SimpleTreeItem
+from model.tree_repo import IMTTreeRepository
+from model.tree_state_mgr import IMTTreeStateManager
+from viewmodel.tree_viewmodel import IMTTreeViewModel
 
-class SimpleTreeViewModel:
-    def __init__(self, tree: SimpleTree):
-        self._tree = tree
-        self._selected_ids: List[str] = []
+class SimpleTreeViewModel(IMTTreeViewModel):
+    """간단한 트리 뷰모델 구현"""
     
-    def get_items_for_display(self) -> List[Dict[str, Any]]:
-        tree_items = self._tree.get_all_items()
+    def __init__(self, repository: IMTTreeRepository, state_manager: IMTTreeStateManager):
+        """뷰모델 초기화
         
-        # 리스트 컴프리헨션 사용
-        return [{
-            "id": item.get_id(),
-            "name": item.get_property("name", ""),
-            "selected": item.get_id() in self._selected_ids
-        } for item_id, item in tree_items.items()]
-    
-    def get_tree_items(self) -> Dict[str, SimpleTreeItem]:
-        """모든 트리 아이템 딕셔너리 반환"""
-        return self._tree.get_all_items()
-    
-    def get_item(self, item_id: str) -> Optional[SimpleTreeItem]:
-        """특정 ID의 트리 아이템 반환"""
-        return self._tree.get_item(item_id)
-    
-    def add_item(self, name: str, parent_id: Optional[str] = None) -> Optional[str]:
+        Args:
+            repository: 트리 저장소
+            state_manager: 트리 상태 관리자
         """
-        새 아이템을 추가합니다.
+        self._repository = repository
+        self._state_mgr = state_manager
+        self._selected_items: Set[str] = set()  # 선택된 아이템 ID 집합
+        self._subscribers: Set[Callable[[], None]] = set()  # 변경 알림을 받을 콜백
+    
+    def get_item(self, item_id: str) -> SimpleTreeItem | None:
+        """ID로 아이템을 찾습니다."""
+        tree = self.get_current_tree()
+        if tree:
+            return tree.get_item(item_id)
+        return None
+    
+    def add_item(self, name: str, parent_id: str | None = None) -> str | None:
+        """새 아이템을 추가합니다.
         
         Args:
             name: 아이템 이름
-            parent_id: 부모 아이템 ID (없으면 루트 아이템)
+            parent_id: 부모 아이템 ID (None이면 최상위 레벨)
             
         Returns:
-            생성된 아이템의 ID 또는 None (실패 시)
+            추가된 아이템 ID 또는 None (실패 시)
         """
-        # 간단한 ID 생성 (실제로는 더 견고한 방식 사용 권장)
-        import uuid
-        item_id = str(uuid.uuid4())
+        tree = self.get_current_tree()
+        if not tree:
+            return None
+        
+        # 상태 저장 (UNDO를 위해)
+        self._state_mgr.save_state(tree)
         
         # 새 아이템 생성
-        from ...model.implementations.simple_tree_item import SimpleTreeItem
+        item_id = str(uuid4())
         new_item = SimpleTreeItem(item_id, name)
         
         # 트리에 추가
-        if self._tree.add_item(new_item, parent_id):
-            # 부모가 있으면 부모 확장
-            if parent_id:
-                parent_item = self._tree.get_item(parent_id)
-                if parent_item:
-                    parent_item.set_property("expanded", True)
+        try:
+            tree.add_item(new_item, parent_id)
+            self._notify_change()
             return item_id
-        return None
+        except ValueError:
+            return None
     
-    def delete_item(self, item_id: str) -> bool:
-        """
-        아이템을 삭제합니다.
+    def get_current_tree(self) -> SimpleTree | None:
+        """현재 트리를 반환합니다."""
+        return self._state_mgr.current_state
+    
+    def get_items(self) -> List[Dict[str, Any]]:
+        """UI에 표시할 아이템 목록을 반환합니다."""
+        tree = self.get_current_tree()
+        if not tree:
+            return []
         
-        Args:
-            item_id: 삭제할 아이템 ID
+        result = []
+        
+        # 트리 순회하면서 아이템 정보 수집
+        def visitor(item: SimpleTreeItem) -> None:
+            parent_id = None
+            for pid, children in tree._children_map.items():
+                if item.id in children:
+                    parent_id = pid
+                    break
             
-        Returns:
-            성공 여부
-        """
-        # 선택된 아이템이면 선택 해제
-        if item_id in self._selected_ids:
-            self._selected_ids.remove(item_id)
-            
-        return self._tree.remove_item(item_id)
+            item_data = {
+                "id": item.id,
+                "parent_id": parent_id,
+                "name": item.get_property("name", "unnamed"),
+                "expanded": item.get_property("expanded", False),
+                "selected": item.id in self._selected_items
+            }
+            result.append(item_data)
+        
+        tree.traverse(visitor)
+        return result
     
-    def update_item(self, item_id: str, name: Optional[str] = None, parent_id: Optional[str] = None) -> bool:
-        """
-        아이템을 업데이트합니다.
+    def load_tree(self, tree_id: str) -> bool:
+        """저장소에서 트리를 로드합니다."""
+        try:
+            tree = self._repository.load(tree_id)
+            if tree:
+                self._state_mgr.set_initial_state(tree)
+                self._selected_items.clear()
+                self._notify_change()
+                return True
+        except ValueError:
+            pass
+        return False
+    
+    def save_tree(self, tree_id: str | None = None) -> str | None:
+        """현재 트리를 저장소에 저장합니다."""
+        tree = self.get_current_tree()
+        if not tree:
+            return None
+        
+        try:
+            saved_id = self._repository.save(tree, tree_id)
+            return saved_id
+        except Exception:
+            return None
+    
+    def update_item(self, item_id: str, name: str | None = None, parent_id: str | None = None) -> bool:
+        """아이템을 업데이트합니다.
         
         Args:
             item_id: 업데이트할 아이템 ID
-            name: 새 이름 (변경 시)
-            parent_id: 새 부모 ID (변경 시)
+            name: 새 이름 (None이면 변경 안 함)
+            parent_id: 새 부모 ID (None이면 변경 안 함)
             
         Returns:
             성공 여부
         """
-        return self._tree.update_item(item_id, name, parent_id)
-    
-    def select_item(self, item_id: str) -> bool:
-        item = self._tree.get_item(item_id)
+        tree = self.get_current_tree()
+        if not tree:
+            return False
+        
+        # 상태 저장 (UNDO를 위해)
+        self._state_mgr.save_state(tree)
+        
+        # 아이템 찾기
+        item = tree.get_item(item_id)
         if not item:
             return False
         
-        # 기존 선택 모두 지우기
-        self._selected_ids.clear()
-        # 새 선택 추가
-        self._selected_ids.append(item_id)
+        # 이름 변경
+        if name is not None:
+            item.set_property("name", name)
+        
+        # 부모 변경
+        if parent_id is not None:
+            try:
+                tree.move_item(item_id, parent_id)
+            except ValueError:
+                return False
+        
+        self._notify_change()
+        return True
+    
+    def remove_item(self, item_id: str) -> bool:
+        """아이템을 삭제합니다."""
+        tree = self.get_current_tree()
+        if not tree:
+            return False
+        
+        # 상태 저장 (UNDO를 위해)
+        self._state_mgr.save_state(tree)
+        
+        # 선택된 아이템에서 제거
+        if item_id in self._selected_items:
+            self._selected_items.remove(item_id)
+        
+        # 트리에서 제거
+        try:
+            tree.remove_item(item_id)
+            self._notify_change()
+            return True
+        except ValueError:
+            return False
+    
+    def select_item(self, item_id: str, multi_select: bool = False) -> bool:
+        """아이템을 선택합니다.
+        
+        Args:
+            item_id: 선택할 아이템 ID
+            multi_select: 다중 선택 모드
+            
+        Returns:
+            성공 여부
+        """
+        tree = self.get_current_tree()
+        if not tree or not tree.get_item(item_id):
+            return False
+        
+        # 다중 선택이 아니면 기존 선택 초기화
+        if not multi_select:
+            self._selected_items.clear()
+        
+        # 선택 토글
+        if item_id in self._selected_items:
+            self._selected_items.remove(item_id)
+        else:
+            self._selected_items.add(item_id)
+        
+        self._notify_change()
         return True
     
     def get_selected_items(self) -> List[str]:
-        return self._selected_ids
-
-    def get_visible_items(self) -> List[Dict[str, Any]]:
-        """화면에 표시할 아이템만 반환 (확장 상태에 따라 필터링)"""
-        result = []
-        
-        # 루트 레벨 아이템 먼저 가져오기
-        root_items = [item for item_id, item in self._tree.get_all_items().items() 
-                     if not item.get_property("parent_id")]
-        
-        # 각 루트 아이템에 대해 자식 아이템 재귀적으로 처리
-        for item in root_items:
-            result.append({
-                "id": item.get_id(),
-                "name": item.get_property("name", ""),
-                "level": 0,  # 루트 레벨
-                "expanded": item.get_property("expanded", False),
-                "selected": item.get_id() in self._selected_ids,
-                "has_children": self._has_children(item.get_id())
-            })
-            
-            # 확장된 상태면 자식도 포함
-            if item.get_property("expanded", False):
-                self._add_children_to_result(item.get_id(), result, 1)  # 레벨 1부터 시작
-        
-        return result
-
-    def _add_children_to_result(self, parent_id: str, result: List[Dict[str, Any]], level: int) -> None:
-        """특정 부모의 자식 아이템을 결과 목록에 추가"""
-        children = self._get_children(parent_id)
-        
-        for child in children:
-            child_id = child.get_id()
-            result.append({
-                "id": child_id,
-                "name": child.get_property("name", ""),
-                "level": level,
-                "expanded": child.get_property("expanded", False),
-                "selected": child_id in self._selected_ids,
-                "has_children": self._has_children(child_id)
-            })
-            
-            # 이 자식이 확장되어 있으면 그 자식들도 추가
-            if child.get_property("expanded", False):
-                self._add_children_to_result(child_id, result, level + 1)
-
-    def _get_children(self, parent_id: str) -> List[SimpleTreeItem]:
-        """특정 부모의 모든 자식 아이템 반환"""
-        return [item for item_id, item in self._tree.get_all_items().items() 
-                if item.get_property("parent_id") == parent_id]
-
-    def _has_children(self, item_id: str) -> bool:
-        """
-        아이템이 자식을 가지고 있는지 확인 (최적화된 버전)
-        모든 아이템을 순회하는 대신 첫 번째 자식 아이템만 찾음
-        """
-        for item in self._tree.get_all_items().values():
-            if item.get_property("parent_id") == item_id:
-                return True
-        return False
-
-    def toggle_expanded(self, item_id: str, expanded: Optional[bool] = None) -> bool:
-        """
-        아이템의 확장/축소 상태 변경
+        """선택된 아이템 ID 목록을 반환합니다."""
+        return list(self._selected_items)
+    
+    def toggle_expanded(self, item_id: str, expanded: bool | None = None) -> bool:
+        """아이템 확장/축소 상태를 토글합니다.
         
         Args:
-            item_id: 아이템 ID
-            expanded: 설정할 상태. None이면 현재 상태 반전
+            item_id: 토글할 아이템 ID
+            expanded: 확장 상태 (None이면 현재 상태의 반대)
+            
+        Returns:
+            성공 여부
         """
-        item = self._tree.get_item(item_id)
+        tree = self.get_current_tree()
+        if not tree:
+            return False
+        
+        item = tree.get_item(item_id)
         if not item:
             return False
         
-        if expanded is None:
-            # 상태 토글
-            current = item.get_property("expanded", False)
-            item.set_property("expanded", not current)
-        else:
-            # 상태 직접 설정
-            item.set_property("expanded", expanded)
-            
+        # 상태 저장 (UNDO를 위해)
+        self._state_mgr.save_state(tree)
+        
+        # 확장 상태 결정
+        current = item.get_property("expanded", False)
+        new_state = not current if expanded is None else expanded
+        
+        # 상태 변경
+        item.set_property("expanded", new_state)
+        
+        self._notify_change()
         return True
-        
-    def move_item(self, item_id: str, new_parent_id: Optional[str] = None) -> bool:
-        """
-        아이템을 다른 부모로 이동합니다.
-        
-        Args:
-            item_id: 이동할 아이템 ID
-            new_parent_id: 새 부모 ID (None이면 루트 레벨로 이동)
-            
-        Returns:
-            성공 여부
-        """
-        return self._tree.update_item(item_id, parent_id=new_parent_id)
     
-    def save_tree(self, file_path: str) -> bool:
-        """
-        현재 트리를 파일에 저장합니다.
-        
-        Args:
-            file_path: 저장할 파일 경로
-            
-        Returns:
-            성공 여부
-        """
-        return self._tree.save_to_file(file_path)
+    def can_undo(self) -> bool:
+        """실행 취소 가능 여부를 반환합니다."""
+        return self._state_mgr.can_undo()
     
-    def load_tree(self, file_path: str) -> bool:
-        """
-        파일에서 트리를 로드합니다.
-        
-        Args:
-            file_path: 불러올 파일 경로
-            
-        Returns:
-            성공 여부
-        """
-        if not os.path.exists(file_path):
+    def can_redo(self) -> bool:
+        """다시 실행 가능 여부를 반환합니다."""
+        return self._state_mgr.can_redo()
+    
+    def undo(self) -> bool:
+        """이전 상태로 되돌립니다."""
+        result = self._state_mgr.undo() is not None
+        if result:
+            self._notify_change()
+        return result
+    
+    def redo(self) -> bool:
+        """다음 상태로 복원합니다."""
+        result = self._state_mgr.redo() is not None
+        if result:
+            self._notify_change()
+        return result
+    
+    def move_item(self, item_id: str, new_parent_id: str | None = None) -> bool:
+        """아이템을 이동합니다."""
+        tree = self.get_current_tree()
+        if not tree:
             return False
-            
-        new_tree = SimpleTree.load_from_file(file_path)
-        if new_tree:
-            self._tree = new_tree
-            self._selected_ids.clear()
+        
+        # 상태 저장 (UNDO를 위해)
+        self._state_mgr.save_state(tree)
+        
+        # 이동 수행
+        try:
+            tree.move_item(item_id, new_parent_id)
+            self._notify_change()
             return True
-        return False
+        except ValueError:
+            return False
+    
+    def get_item_children(self, parent_id: str | None = None) -> List[Dict[str, Any]]:
+        """특정 부모의 자식 아이템 정보를 반환합니다."""
+        tree = self.get_current_tree()
+        if not tree:
+            return []
+        
+        result = []
+        children = tree.get_children(parent_id)
+        
+        for child in children:
+            item_data = {
+                "id": child.id,
+                "name": child.get_property("name", "unnamed"),
+                "expanded": child.get_property("expanded", False),
+                "selected": child.id in self._selected_items
+            }
+            result.append(item_data)
+        
+        return result
+    
+    def subscribe(self, callback: Callable[[], None]) -> None:
+        """변경 알림을 구독합니다."""
+        self._subscribers.add(callback)
+    
+    def unsubscribe(self, callback: Callable[[], None]) -> None:
+        """변경 알림 구독을 해제합니다."""
+        if callback in self._subscribers:
+            self._subscribers.remove(callback)
+    
+    def _notify_change(self) -> None:
+        """모든 구독자에게 변경을 알립니다."""
+        for callback in self._subscribers:
+            callback()

--- a/viewmodel/tree_viewmodel.py
+++ b/viewmodel/tree_viewmodel.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Protocol
+from typing import Any, Callable, Dict, List, Protocol
 
 from core.tree import IMTTree, IMTTreeModifiable, IMTTreeData, IMTTreeTraversable
 from model.tree_item import IMTTreeItem
@@ -17,11 +17,11 @@ class IMTTreeViewModel(Protocol):
         """저장소에서 트리 로드"""
         ...
     
-    def save_tree(self, tree_id: Optional[str] = None) -> str:
+    def save_tree(self, tree_id: str | None = None) -> str:
         """현재 트리를 저장소에 저장"""
         ...
     
-    def get_current_tree(self) -> Optional[IMTTree]:
+    def get_current_tree(self) -> IMTTree | None:
         """현재 로드된 트리 반환"""
         ...
     
@@ -37,7 +37,7 @@ class IMTTreeViewModel(Protocol):
         """선택된 아이템 ID 목록 반환"""
         ...
     
-    def add_item(self, parent_id: Optional[str], data: Dict[str, Any]) -> str:
+    def add_item(self, parent_id: str | None, data: Dict[str, Any]) -> str:
         """부모 아래에 새 아이템 추가 (IMTTreeModifiable 사용)"""
         ...
     
@@ -45,11 +45,11 @@ class IMTTreeViewModel(Protocol):
         """아이템 제거 (IMTTreeModifiable 사용)"""
         ...
     
-    def move_item(self, item_id: str, new_parent_id: Optional[str]) -> bool:
+    def move_item(self, item_id: str, new_parent_id: str | None) -> bool:
         """아이템 이동 (IMTTreeModifiable 사용)"""
         ...
     
-    def get_item_children(self, parent_id: Optional[str]) -> List[Dict[str, Any]]:
+    def get_item_children(self, parent_id: str | None) -> List[Dict[str, Any]]:
         """특정 부모의 자식 아이템 목록 (IMTTreeReadable 사용)"""
         ...
     


### PR DESCRIPTION
- Rename action_types.py to base_action.py for naming consistency
- Rename actions.py to action.py (singular form)
- Move all action-related interfaces to base_action.py
- Update type hints from Optional[Type] to Type | None
- Organize TreeItemKeys by logical groups
- Remove duplicate code from base_item.py
- Fix import paths across affected files